### PR TITLE
Fix broken source URI in zen-browser packages

### DIFF
--- a/.github/workflows/zen-browser-sync.yml
+++ b/.github/workflows/zen-browser-sync.yml
@@ -35,8 +35,8 @@ jobs:
           ZEN_VER_SPEC=$(echo $ZEN_VER | sed 's@-@.@g')
           sed -i '0,/Version:.*/s//Version:            '$ZEN_VER_SPEC'/' /home/runner/work/copr/copr/zen-browser/zen-browser.spec
           sed -i '0,/Version:.*/s//Version:            '$ZEN_VER_SPEC'/' /home/runner/work/copr/copr/zen-browser/zen-browser-aarch64.spec
-          sed -i 's@https://github.com/zen-browser/desktop/releases/download/.*@https://github.com/zen-browser/desktop/releases/download/'$ZEN_VER'/zen.linux-x86_64.tar.bz2@g' /home/runner/work/copr/copr/zen-browser/zen-browser.spec
-          sed -i 's@https://github.com/zen-browser/desktop/releases/download/.*@https://github.com/zen-browser/desktop/releases/download/'$ZEN_VER'/zen.linux-aarch64.tar.bz2@g' /home/runner/work/copr/copr/zen-browser/zen-browser-aarch64.spec
+          sed -i 's@https://github.com/zen-browser/desktop/releases/download/.*@https://github.com/zen-browser/desktop/releases/download/'$ZEN_VER'/zen.linux-x86_64.tar.xz@g' /home/runner/work/copr/copr/zen-browser/zen-browser.spec
+          sed -i 's@https://github.com/zen-browser/desktop/releases/download/.*@https://github.com/zen-browser/desktop/releases/download/'$ZEN_VER'/zen.linux-aarch64.tar.xz@g' /home/runner/work/copr/copr/zen-browser/zen-browser-aarch64.spec
 
       - name: update-zen-browser-twilight-spec
         id: update_twilight

--- a/zen-browser/zen-browser-aarch64.spec
+++ b/zen-browser/zen-browser-aarch64.spec
@@ -9,7 +9,7 @@ Summary:            Zen Browser
 
 License:            MPLv2.0
 URL:                https://github.com/zen-browser/desktop
-Source0:            https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-aarch64.tar.bz2
+Source0:            https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-aarch64.tar.xz
 Source1:            %{full_name}.desktop
 Source2:            policies.json
 Source3:            %{full_name}

--- a/zen-browser/zen-browser-avx2.spec
+++ b/zen-browser/zen-browser-avx2.spec
@@ -9,7 +9,7 @@ Summary:            Zen Browser
 
 License:            MPLv2.0
 URL:                https://github.com/zen-browser/desktop
-Source0:            https://github.com/zen-browser/desktop/releases/download/1.0.2-b.3/zen.linux-specific.tar.bz2
+Source0:            https://github.com/zen-browser/desktop/releases/download/1.0.2-b.3/zen.linux-specific.tar.xz
 Source1:            %{full_name}.desktop
 Source2:            policies.json
 Source3:            %{full_name}

--- a/zen-browser/zen-browser.spec
+++ b/zen-browser/zen-browser.spec
@@ -9,7 +9,7 @@ Summary:            Zen Browser
 
 License:            MPLv2.0
 URL:                https://github.com/zen-browser/desktop
-Source0:            https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-x86_64.tar.bz2
+Source0:            https://github.com/zen-browser/desktop/releases/download/1.7.6b/zen.linux-x86_64.tar.xz
 Source1:            %{full_name}.desktop
 Source2:            policies.json
 Source3:            %{full_name}

--- a/zen-browser/zen-twilight-aarch64.spec
+++ b/zen-browser/zen-twilight-aarch64.spec
@@ -10,7 +10,7 @@ Summary:            Zen Browser (Twilight)
 License:            MPLv2.0
 URL:                https://github.com/zen-browser/desktop
 
-Source0:            https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-aarch64.tar.bz2
+Source0:            https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-aarch64.tar.xz
 Source1:            %{full_name}.desktop
 Source2:            policies.json
 Source3:            %{full_name}

--- a/zen-browser/zen-twilight.spec
+++ b/zen-browser/zen-twilight.spec
@@ -10,7 +10,7 @@ Summary:            Zen Browser (Twilight)
 License:            MPLv2.0
 URL:                https://github.com/zen-browser/desktop
 
-Source0:            https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-x86_64.tar.bz2
+Source0:            https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-x86_64.tar.xz
 Source1:            %{full_name}.desktop
 Source2:            policies.json
 Source3:            %{full_name}


### PR DESCRIPTION
Recent build of the zen-browser(-aarch64) and zen-twilight(-aarch64) failed, as the file format of the binary releases on Zens GitHub changed from `tar.bz2` to `tar.xz`. This change was made in https://github.com/zen-browser/desktop/commit/faff428afbb185faa3f54686c87112ccc64537fa

This PR should resolve this issue.