### PR TITLE
fix(zen-browser): Fix broken package build

### DIFF
--- a/zen-browser/zen-browser.spec
+++ b/zen-browser/zen-browser.spec
@@ -53,6 +53,8 @@ Bugs related to this package should be reported at this Git project:
 
 %__install -D -m 0755 %{SOURCE3} -t %{buildroot}%{_bindir}
 
+patchelf --set-rpath '$ORIGIN' %{buildroot}/opt/%{application_name}/libonnxruntime.so
+
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default128.png %{buildroot}%{_datadir}/icons/hicolor/128x128/apps/%{full_name}.png
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default64.png %{buildroot}%{_datadir}/icons/hicolor/64x64/apps/%{full_name}.png
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default48.png %{buildroot}%{_datadir}/icons/hicolor/48x48/apps/%{full_name}.png

--- a/zen-browser/zen-twilight.spec
+++ b/zen-browser/zen-twilight.spec
@@ -54,6 +54,8 @@ mv zen %{application_name}
 
 %__install -D -m 0755 %{SOURCE3} -t %{buildroot}%{_bindir}
 
+patchelf --set-rpath '$ORIGIN' %{buildroot}/opt/%{application_name}/libonnxruntime.so
+
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default128.png %{buildroot}%{_datadir}/icons/hicolor/128x128/apps/%{full_name}.png
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default64.png %{buildroot}%{_datadir}/icons/hicolor/64x64/apps/%{full_name}.png
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default48.png %{buildroot}%{_datadir}/icons/hicolor/48x48/apps/%{full_name}.png


### PR DESCRIPTION
resolves #10 

This Change fixes the following error currently being reported by the QA Checks:

```
ERROR   0002: file '/opt/zen/libonnxruntime.so' contains an invalid runpath '$' in [$]
```

This is done by patching `libonnxruntime.so` to use `$ORIGIN` instead of  `$`.
This only applies to the x86_64 build, as the AARCH64 build does not experience this issue.

In my short testing this build works without any problems - **I am not too experienced with ELF runpaths, so there might be something I am missing here.**
